### PR TITLE
Transfer repo to the 'fcrepo-exts' GitHub org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ Example:
 * Could this change impact execution of existing code?
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
+Tag (@ mention) interested parties or, if unsure, @fcrepo/committers

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of ready-to-use messaging applications for use
 with [Fedora4](http://fcrepo.org). These applications use
 [Apache Camel](https://camel.apache.org).
 
-[![Build Status](https://travis-ci.org/fcrepo4-exts/fcrepo-camel-toolbox.png?branch=master)](https://travis-ci.org/fcrepo4-exts/fcrepo-camel-toolbox)
+[![Build Status](https://travis-ci.org/fcrepo-exts/fcrepo-camel-toolbox.png?branch=master)](https://travis-ci.org/fcrepo-exts/fcrepo-camel-toolbox)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/toolbox-features/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/toolbox-features/)
 
 Additional background information is available on the Fedora Wiki on the

--- a/fcrepo-fixity/README.md
+++ b/fcrepo-fixity/README.md
@@ -9,7 +9,7 @@ modified by specifying an alternate value for `fixity.failure`. It is
 also possible to trigger an event on successful fixity checks.
 
 This service is typically used in conjunction with the
-[fcrepo-reindexing](https://github.com/fcrepo4-exts/fcrepo-camel-toolbox/tree/master/fcrepo-reindexing)
+[fcrepo-reindexing](https://github.com/fcrepo-exts/fcrepo-camel-toolbox/tree/master/fcrepo-reindexing)
 module. For example:
 
     curl -XPOST localhost:9080/reindexing/fedora/path -H"Content-Type: application/json" \

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
 
   <properties>
     <!-- Use ${project_name} instead of ${project.artifactId} to avoid incorrect
-      replacements of "fcrepo4" in child modules (for scm, site-distribution, etc -->
+      replacements of "fcrepo" in child modules (for scm, site-distribution, etc -->
     <project_name>fcrepo-camel-toolbox</project_name>
-    <project_organization>fcrepo4-exts</project_organization>
+    <project_organization>fcrepo-exts</project_organization>
     <project.copyrightYear>2016</project.copyrightYear>
 
     <!-- version ranges -->
@@ -656,7 +656,7 @@
   </developers>
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/fcrepo4-exts/fcrepo-camel-toolbox/issues</url>
+    <url>https://github.com/fcrepo-exts/fcrepo-camel-toolbox/issues</url>
   </issueManagement>
 
   <ciManagement>
@@ -665,9 +665,9 @@
   </ciManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/fcrepo4-exts/fcrepo-camel-toolbox.git</connection>
-    <developerConnection>scm:git:git@github.com:fcrepo4-exts/fcrepo-camel-toolbox.git</developerConnection>
-    <url>https://github.com/fcrepo4-exts/fcrepo-camel-toolbox</url>
+    <connection>scm:git:git://github.com/fcrepo-exts/fcrepo-camel-toolbox.git</connection>
+    <developerConnection>scm:git:git@github.com:fcrepo-exts/fcrepo-camel-toolbox.git</developerConnection>
+    <url>https://github.com/fcrepo-exts/fcrepo-camel-toolbox</url>
     <tag>HEAD</tag>
   </scm>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -2,7 +2,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 
     http://maven.apache.org/xsd/decoration-1.6.0.xsd"
-    name="fcrepo4">
+    name="fcrepo">
 
   <skin>
     <!-- see http://maven.apache.org/skins/maven-fluido-skin/ -->
@@ -14,8 +14,8 @@
   <body>
     <links>
       <item name="Fedora" href="http://fcrepo.org/" />
-      <item name="Fedora 4 on GitHub" href="http://github.com/fcrepo4/" />
-      <item name="Developer Documentation" href="http://fcrepo4-exts.github.com/fcrepo-camel-toolbox/" />
+      <item name="Fedora 4 on GitHub" href="http://github.com/fcrepo/" />
+      <item name="Developer Documentation" href="http://fcrepo-exts.github.com/fcrepo-camel-toolbox/" />
     </links>
 
     <breadcrumbs>


### PR DESCRIPTION
No functional change.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
