### PR TITLE
Fix CamelFcrepoUri header when reindexing

### DIFF
--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
@@ -76,7 +76,7 @@ public class ReindexingRouter extends RouteBuilder {
                 "?matchOnUriPrefix=true&httpMethodRestrict=GET,POST")
                 .routeId("FcrepoReindexingRest")
                 .routeDescription("Expose the reindexing endpoint over HTTP")
-                .setHeader(FCREPO_URI).simple("${headers.CamelHttpPath}")
+                .setHeader(FCREPO_URI).simple(config.getFcrepoBaseUrl() + "${headers.CamelHttpPath}")
             .choice()
                 .when(header(HTTP_METHOD).isEqualTo("GET")).to("direct:usage")
                 .otherwise().to("direct:reindex");
@@ -112,7 +112,7 @@ public class ReindexingRouter extends RouteBuilder {
                     .transform().simple("Indexing started at ${headers[CamelFcrepoUri]}");
 
         /**
-         *  A route that traverses through a fedora heirarchy
+         *  A route that traverses through a fedora hierarchy
          *  indexing nodes, as appropriate.
          */
         from(config.getReindexingStream() + "?asyncConsumer=true").routeId("FcrepoReindexingTraverse")


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3759

# What does this Pull Request do?

Updates the `CamelFcrepoUri` header to include the `fcrepoBaseUrl` when reindexing.

# How should this be tested?

Start up Fedora, Solr, and Fuseki then run the camel toolbox, create a resource, and issue a reindex command on the created resource uuid:
```
java -jar fcrepo-camel-toolbox-app/target/fcrepo-camel-toolbox-app-6.0.0-SNAPSHOT-driver.jar -c configuration.properties
curl -X POST --user fedoraAdmin:fedoraAdmin http://localhost:8080/fcrepo/rest
curl -XPOST localhost:9080/reindexing/${UUID} -H"Content-Type: application/json" -d '["broker:queue:solr.reindex"]'
```

# Interested parties
@fcrepo/committers
