### PR TITLE
Re-enable checkstyles for Solr indexer.

### DIFF
--- a/fcrepo-indexing-solr/pom.xml
+++ b/fcrepo-indexing-solr/pom.xml
@@ -94,10 +94,10 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
 
-      <!--plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin-->
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
@@ -118,7 +118,10 @@ public class SolrRouter extends RouteBuilder {
                     .setHeader(INDEXING_TRANSFORMATION).simple(config.getDefaultTransform())
                     .to("direct:update.solr")
                 .otherwise()
-                    .to("fcrepo:" + config.getFcrepoBaseUrl() + "?preferOmit=PreferContainment&accept=application/rdf+xml")
+                    .to(
+                        "fcrepo:" + config.getFcrepoBaseUrl()
+                        + "?preferOmit=PreferContainment&accept=application/rdf+xml"
+                    )
                     .setHeader(INDEXING_TRANSFORMATION).xpath(hasIndexingTransformation, String.class, ns)
                     .choice()
                         .when(or(header(INDEXING_TRANSFORMATION).isNull(),


### PR DESCRIPTION
As mentioned in #166, the Solr indexer had checkstyles disabled for some reason; this PR re-enables it and fixes the one long line that was causing a failure.