### PR TITLE
Property Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ the entire `LDPath` program. The `Content-Type` of the request should be either 
 #### Properties
 | Name      | Description| Default Value |
 | :---      | :---| :----   |
-| fcrepo.cache.timeout | The timeout in seconds for the ldpath cache | 0 |
-| rest.prefix | The LDPath rest endpoint prefix |  no | /ldpath|
-| rest.port| The LDPath rest endpoint port |  no | 9085 |
-| rest.host| The LDPath rest endpoint host |  no | localhost |
-| cache.timeout | LDCache ?  timeout in seconds  |  no | 86400  |
+| ldpath.cache.timeout | The timeout in seconds for the ldpath cache | 0 |
+| ldpath.rest.prefix | The LDPath rest endpoint prefix |  no | /ldpath|
+| ldpath.rest.port| The LDPath rest endpoint port |  no | 9085 |
+| ldpath.rest.host| The LDPath rest endpoint host |  no | localhost |
+| ldcache.timeout | LDCache ?  timeout in seconds  |  no | 86400  |
 | ldcache.directory | LDCache directory  |  no | ldcache/  |
 | ldpath.transform.path | The LDPath transform file path | classpath:org/fcrepo/camel/ldpath/default.ldpath |
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ the entire `LDPath` program. The `Content-Type` of the request should be either 
 | ldpath.rest.prefix | The LDPath rest endpoint prefix |  no | /ldpath|
 | ldpath.rest.port| The LDPath rest endpoint port |  no | 9085 |
 | ldpath.rest.host| The LDPath rest endpoint host |  no | localhost |
-| ldcache.timeout | LDCache ?  timeout in seconds  |  no | 86400  |
+| ldcache.timeout | LDCache timeout in seconds  |  no | 86400  |
 | ldcache.directory | LDCache directory  |  no | ldcache/  |
 | ldpath.transform.path | The LDPath transform file path | classpath:org/fcrepo/camel/ldpath/default.ldpath |
 
@@ -277,7 +277,7 @@ the repository.
 | fixity.success|  It is also possible to trigger an action on success. By default, this is a no-op. The value should be a camel route action.  To log it to a file use something like this:  file:/tmp/?fileName=fixity-succes.log&fileExist=Append | null |
 | fixity.failure |  Most importantly, it is possible to configure what should happen when a fixity check fails. In the default example below, the fixity output is written to a file in `/tmp/fixityErrors.log`. But this can be changed to send a message to an email address (`fixity.failure=smtp:admin@example.org?subject=Fixity`) or use just about any other camel component.| file:/tmp/?fileName=fixity-errors.log&fileExist=Append |
 
-## Building
+## Troubleshooting
 
 ### java.lang.IllegalArgumentException: Credentials may not be null
 

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/FcrepoLdPathConfig.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/FcrepoLdPathConfig.java
@@ -49,19 +49,19 @@ import static java.util.Collections.EMPTY_SET;
 @Configuration
 public class FcrepoLdPathConfig extends BasePropsConfig {
 
-    @Value("${fcrepo.cache.timeout:0}")
+    @Value("${ldpath.cache.timeout:0}")
     private long fcrepoCacheTimeout;
 
-    @Value("${rest.prefix:/ldpath}")
+    @Value("${ldpath.rest.prefix:/ldpath}")
     private String restPrefix;
 
-    @Value("${rest.host:localhost}")
+    @Value("${ldpath.rest.host:localhost}")
     private String restHost;
 
-    @Value("${rest.port:9085}")
+    @Value("${ldpath.rest.port:9085}")
     private int restPort;
 
-    @Value("${cache.timeout:86400}")
+    @Value("${ldcache.timeout:86400}")
     private int cacheTimeout;
 
     @Value("${ldcache.directory:ldcache/}")

--- a/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
+++ b/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
@@ -82,8 +82,8 @@ public class RouteTest {
         new File(ldCacheDir).mkdirs();
         System.setProperty("ldcache.directory", ldCacheDir);
         final String restPort = System.getProperty("fcrepo.dynamic.ldpath.port", "9085");
-        System.setProperty("rest.port", restPort);
-        System.setProperty("rest.host", "0.0.0.0");
+        System.setProperty("ldpath.rest.port", restPort);
+        System.setProperty("ldpath.rest.host", "127.0.0.1");
     }
 
     @AfterClass
@@ -93,7 +93,6 @@ public class RouteTest {
 
     @Test
     public void testGetDefault() throws Exception {
-
         final String uri = "http://fedora.info/definitions/v4/event#ResourceCreation";
         final String endpoint = "mock:resultGet";
         final MockEndpoint mockEndpoint = (MockEndpoint) camelContext.getEndpoint(endpoint);
@@ -132,7 +131,6 @@ public class RouteTest {
 
         template.sendBodyAndHeader(null, HTTP_METHOD, "OPTIONS");
         optionsEndpoint.assertIsSatisfied();
-
     }
 
     @Test
@@ -201,7 +199,6 @@ public class RouteTest {
         assertTrue(data.get(0).get("label").contains("Fedora Container"));
         assertTrue(data.get(0).get("type").contains("Class"));
         assertTrue(data.get(0).get("id").contains(uri));
-
     }
 
 

--- a/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteWithFunctionsTest.java
+++ b/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteWithFunctionsTest.java
@@ -84,9 +84,8 @@ public class RouteWithFunctionsTest {
 
         System.setProperty("ldcache.directory", ldCacheDir);
         final String restPort = System.getProperty("fcrepo.dynamic.ldpath.port", "9085");
-        System.setProperty("rest.port", restPort);
-        System.setProperty("rest.host", "0.0.0.0");
-
+        System.setProperty("ldpath.rest.port", restPort);
+        System.setProperty("ldpath.rest.host", "127.0.0.1");
     }
 
     @AfterClass
@@ -203,7 +202,6 @@ public class RouteWithFunctionsTest {
         assertTrue(data.get(0).get("label").contains("Fedora Container"));
         assertTrue(data.get(0).get("type").contains("Class"));
         assertTrue(data.get(0).get("id").contains(uri));
-
     }
 
     @Test
@@ -218,7 +216,6 @@ public class RouteWithFunctionsTest {
         AdviceWith.adviceWith(context, "FcrepoLDPathPrepare", a -> {
             a.weaveAddLast().to(endpoint);
         });
-
 
         template.sendBodyAndHeader("direct:ldpathPrepare",
                 loadResourceAsStream("test-with-functions.ldpath"),
@@ -238,7 +235,6 @@ public class RouteWithFunctionsTest {
         assertTrue(data.get(0).get("type").contains("Class"));
         assertTrue(data.get(0).get("id").contains(uri));
         assertTrue(data.get(0).get("description").contains("Class : Fedora Container"));
-
     }
 
 

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/FcrepoReindexerConfig.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/FcrepoReindexerConfig.java
@@ -20,8 +20,6 @@ package org.fcrepo.camel.reindexing;
 import org.apache.camel.builder.RouteBuilder;
 import org.fcrepo.camel.common.config.BasePropsConfig;
 import org.fcrepo.camel.common.config.ConditionOnPropertyTrue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -32,13 +30,11 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author dbernstein
  */
-
 @Configuration
 @Conditional(FcrepoReindexerConfig.ReindexerEnabled.class)
 public class FcrepoReindexerConfig extends BasePropsConfig {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FcrepoReindexerConfig.class);
-    static final String REINDEXER_ENABLED = "reindexer.enabled";
+    static final String REINDEXER_ENABLED = "reindexing.enabled";
 
     static class ReindexerEnabled extends ConditionOnPropertyTrue {
         ReindexerEnabled() {


### PR DESCRIPTION
# What does this Pull Request do?

* Update prefix for ldpath properties to be either ldpath or ldcache
* Update FcrepoReindexerConfig to use reindexing.enabled

# How should this be tested?

* Run the camel toolbox with updated ldpath configuration to ensure they are set correctly

# Additional Notes

I wasn't sure for the ldcache properties if they should be `ldpath.ldcache.*` or `ldcache.*` but they seemed distinct enough to be `ldcache`. Can switch to `ldpath.ldcache.*` if desired.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
