### PR TITLE
Update reindexing usage text

### DIFF
--- a/fcrepo-camel-common/src/main/java/org/fcrepo/camel/common/processor/DockerRunningProcessor.java
+++ b/fcrepo-camel-common/src/main/java/org/fcrepo/camel/common/processor/DockerRunningProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel.common.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+import java.nio.file.Path;
+
+/**
+ * Processor for determining if the application is currently running in
+ * a Docker environment. Adds a header `CamelDockerRunning` of type boolean
+ * to the exchange headers.
+ *
+ * WARNING
+ * Checks for existence of /.dockerenv in the filesystem. Note that the presence
+ * of this file is not documented and that this check might not work in the future.
+ *
+ * See <a href="https://superuser.com/questions/1021834/what-are-dockerenv-and-dockerinit">...</a>
+ *
+ * @author Ralf Claussnitzer
+ */
+public class DockerRunningProcessor implements Processor {
+
+    public static final String DOCKER_RUNNING = "CamelDockerRunning";
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        boolean dockerenvExists = Path.of("/.dockerenv").toFile().exists();
+        exchange.getMessage().setHeader(DOCKER_RUNNING, dockerenvExists);
+    }
+}

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
@@ -8,6 +8,7 @@ package org.fcrepo.camel.reindexing;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
+import org.fcrepo.camel.common.processor.DockerRunningProcessor;
 import org.fcrepo.camel.service.FcrepoCamelConfig;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,7 @@ public class ReindexingRouter extends RouteBuilder {
                 .setHeader(REINDEXING_PREFIX).simple(config.getRestPrefix())
                 .setHeader(REINDEXING_PORT).simple(String.valueOf(port))
                 .setHeader(FCREPO_BASE_URL).simple(fcrepoCamelConfig.getFcrepoBaseUrl())
+                .process(new DockerRunningProcessor())
             .process(exchange -> {
                 exchange.getIn().setHeader(REINDEXING_HOST, getLocalHost().getHostName());
             })

--- a/fcrepo-reindexing/src/main/resources/org/fcrepo/camel/reindexing/usage.mustache
+++ b/fcrepo-reindexing/src/main/resources/org/fcrepo/camel/reindexing/usage.mustache
@@ -1,4 +1,4 @@
-Fedora Reindexing Service
+Fedora Reindexing Service {{#headers.CamelDockerRunning}}(Running in Docker){{/headers.CamelDockerRunning}}
 
     Configured Fedora Location: {{headers.CamelFcrepoBaseUrl}}
     Configured REST endpoint: {{headers.CamelReindexingHost}}:{{headers.CamelReindexingPort}}{{headers.CamelReindexingPrefix}}
@@ -8,6 +8,12 @@ will begin to traverse the Fedora repository at that point,
 sending "re-indexing" hints to the specified services
 (there are no default services defined).
 
+{{#headers.CamelDockerRunning}}
+Note: The mentioned hostname and port might not work on your host machine when running
+    Camel Toolbox as Docker container. You can usually access the reindexing service on
+    localhost:9080 when you docker-compose.
+
+{{/headers.CamelDockerRunning}}
 For example:
 
   curl -XPOST {{headers.CamelReindexingHost}}:{{headers.CamelReindexingPort}}{{headers.CamelReindexingPrefix}}/objects \


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3804

# What does this Pull Request do?
Add note about potential hostname issues while running in a
Docker environment. Checks for Docker environment using undocumented
'hack' by looking for the presence of .dockerenv file.

# What's new?
Add a new class DockerRunningProcessor which potentially detects the presence of a Docker environment and sets a specific Camel Exchange header.

# How should this be tested?
Running outside of Docker should print the /reindexing usage message as before.
Running inside a Docker environment supplements the /reindexing usage message with a Docker specific note.

# Additional Notes:
There is no standard way of checking for a container environment. It all depends on the presence of the undocumented .dockerenv file which might disappear in future docker releases. This however, seems unlikely because it's a very common way of checking for Docker.

# Interested parties
@dbernstein 
