### PR TITLE
Enable graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 fcrepo4-data/
+ldcache/
 *transaction.log
 *~
 

--- a/fcrepo-camel-toolbox-app/src/main/java/org/fcrepo/camel/toolbox/app/Driver.java
+++ b/fcrepo-camel-toolbox-app/src/main/java/org/fcrepo/camel/toolbox/app/Driver.java
@@ -46,11 +46,7 @@ public class Driver implements Callable<Integer> {
         LOGGER.info("fcrepo-camel-toolbox started.");
 
         while (appContext.isRunning()) {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException("This should never happen");
-            }
+            Thread.onSpinWait();
         }
         return 0;
     }

--- a/fcrepo-camel-toolbox-app/src/main/java/org/fcrepo/camel/toolbox/app/Driver.java
+++ b/fcrepo-camel-toolbox-app/src/main/java/org/fcrepo/camel/toolbox/app/Driver.java
@@ -42,6 +42,7 @@ public class Driver implements Callable<Integer> {
             System.setProperty(FCREPO_CAMEL_CONFIG_FILE_PROPERTY, configurationFilePath.toFile().getAbsolutePath());
         }
         final var appContext = new AnnotationConfigApplicationContext("org.fcrepo.camel");
+        appContext.registerShutdownHook();
         appContext.start();
         LOGGER.info("fcrepo-camel-toolbox started.");
 


### PR DESCRIPTION
# What does this Pull Request do?
Changes the busy-wait pattern from sleep to JVM hint, allowing the JVM to optimize processor usage.
Adds a shutdown hook to allow Spring to shutdown the Camel context if the application receives a termination signal.

# What's new?

* Replace Thread.wait() with Thread.onSpinWait()
* Added application context shutdown hook

# How should this be tested?
Run and stop the application. Should yield Camel shutdown messages in the log.

# Interested parties
@dbernstein 
