### PR TITLE
Update commons-codec version and include it in shaded jar

### DIFF
--- a/fcrepo-camel-toolbox-app/pom.xml
+++ b/fcrepo-camel-toolbox-app/pom.xml
@@ -117,6 +117,7 @@
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>driver</shadedClassifierName>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.fcrepo.camel.toolbox.app.Driver</mainClass>
                 </transformer>

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,6 @@
     <project_organization>fcrepo-exts</project_organization>
     <project.copyrightYear>2016</project.copyrightYear>
 
-    <!-- version ranges -->
-    <activemq.version.range>[5.16.0,6)</activemq.version.range>
-    <camel.version.range>[3.9.0,4)</camel.version.range>
-
     <!-- dependencies -->
     <activemq.version>5.16.0</activemq.version>
     <camel.version>3.9.0</camel.version>
@@ -55,7 +51,7 @@
 
     <!-- testing -->
     <awaitility.version>1.7.0</awaitility.version>
-    <commons.codec.version>1.10</commons.codec.version>
+    <commons.codec.version>1.15</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.16</grizzly.version>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3892 and #192 

# What does this Pull Request do?
Updates the version of `commons-codec` and adds the ServicesResourceTransformer to the shade plugin to ensure the Jena dependencies end up in the final jar.

# How should this be tested?

Make a container with some blank nodes (see linked tickets), then try to index it to a triplestore.

**Before PR**: get a stacktrace with `java.lang.NoClassDefFoundError: org/apache/commons/codec/digest/MurmurHash3` in it.

**After PR**: resource is indexed to triplestore

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? yes and no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
