### PR TITLE
Stop using onSpinWait

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ This application listens to Fedora's event stream and
 indexes objects into an external Solr server.
 
 #### Properties
-| Name      | Description                                                                                                                                                 | Default Value |
-| :---      |:------------------------------------------------------------------------------------------------------------------------------------------------------------| :----   |
-| solr.indexing.enabled | Enables/disables the SOLR indexing service. Disabled by default                                                                                             | false | 
+| Name      | Description | Default Value |
+| :---      |:---| :----   |
+| solr.indexing.enabled | Enables/disables the SOLR indexing service. Disabled by default | false | 
 | solr.fcrepo.checkHasIndexingTransformation | When true, check for an indexing transform in the resource metadata with the predicate http://fedora.info/definitions/v4/indexing#hasIndexingTransformation | true |
-| solr.fcrepo.defaultTransform | The solr default XSL transform when none is provide in resource metadata.                                                                                   | null | 
-| solr.input.stream | The JMS topic or queue serving as the message source                                                                                                        | broker:topic:fedora |
-| solr.reindex.stream | The JMS topic or queue serving as the reindex message source                                                                                                | broker:queue:solr.reindex |
-| solr.commitWithin | Milliseconds within which commits should occur                                                                                                              | 10000 |
-| solr.indexing.predicate | When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.                                  | false |
-| solr.filter.containers | A comma-separate list of containers that should be ignored by the indexer                                                                                   | http://localhost:8080/fcrepo/rest/audit |
+| solr.fcrepo.defaultTransform | The solr default XSL transform when none is provide in resource metadata. | null | 
+| solr.input.stream | The JMS topic or queue serving as the message source | broker:topic:fedora |
+| solr.reindex.stream | The JMS topic or queue serving as the reindex message source | broker:queue:solr.reindex |
+| solr.commitWithin | Milliseconds within which commits should occur | 10000 |
+| solr.indexing.predicate | When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.| false |
+| solr.filter.containers | A comma-separate list of containers that should be ignored by the indexer| http://localhost:8080/fcrepo/rest/audit |
 
 **Note**: You must start with the `file://` protocol when defining the path to a custom XSLT for either the `solr.fcrepo.defaultTransform` 
 or within the resource using the `http://fedora.info/definitions/v4/indexing#hasIndexingTransformation` predicate. 

--- a/README.md
+++ b/README.md
@@ -124,17 +124,29 @@ This application listens to Fedora's event stream and
 indexes objects into an external Solr server.
 
 #### Properties
-| Name      | Description| Default Value |
-| :---      | :---| :----   |
-| solr.indexing.enabled | Enables/disables the SOLR indexing service. Disabled by default | false | 
-| solr.fcrepo.checkHasIndexingTransformation | When true, check for an indexing transform in the  resource matadata.    | true |
-| solr.fcrepo.defaultTransform |   The solr default XSL transform when none is provide in resource metadata.  | null | 
-| solr.input.stream |   The JMS topic or queue serving as the message source    | broker:topic:fedora |
-| solr.reindex.stream |   The JMS topic or queue serving as the reindex message source    | broker:queue:solr.reindex |
-| solr.commitWithin |   Milliseconds within which commits should occur    | 10000 |
-| solr.indexing.predicate |  When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.   | false |
-| solr.filter.containers |   A comma-separate list of containers that should be ignored by the indexer  | http://localhost:8080/fcrepo/rest/audit |
+| Name      | Description                                                                                                                                                 | Default Value |
+| :---      |:------------------------------------------------------------------------------------------------------------------------------------------------------------| :----   |
+| solr.indexing.enabled | Enables/disables the SOLR indexing service. Disabled by default                                                                                             | false | 
+| solr.fcrepo.checkHasIndexingTransformation | When true, check for an indexing transform in the resource metadata with the predicate http://fedora.info/definitions/v4/indexing#hasIndexingTransformation | true |
+| solr.fcrepo.defaultTransform | The solr default XSL transform when none is provide in resource metadata.                                                                                   | null | 
+| solr.input.stream | The JMS topic or queue serving as the message source                                                                                                        | broker:topic:fedora |
+| solr.reindex.stream | The JMS topic or queue serving as the reindex message source                                                                                                | broker:queue:solr.reindex |
+| solr.commitWithin | Milliseconds within which commits should occur                                                                                                              | 10000 |
+| solr.indexing.predicate | When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.                                  | false |
+| solr.filter.containers | A comma-separate list of containers that should be ignored by the indexer                                                                                   | http://localhost:8080/fcrepo/rest/audit |
 
+**Note**: You must start with the `file://` protocol when defining the path to a custom XSLT for either the `solr.fcrepo.defaultTransform` 
+or within the resource using the `http://fedora.info/definitions/v4/indexing#hasIndexingTransformation` predicate. 
+
+For example, 
+```text
+solr.fcrepo.defaultTransform=file:///path/to/your/transform.xsl
+```
+or
+```text
+@prefix indexing: <http://fedora.info/definitions/v4/indexing#> .
+<> indexing:hasIndexingTransformation <file:///path/to/your/transform.xsl> .
+```
 
 ### Repository Indexer (Triplestore)
 

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/FcrepoSolrIndexingConfig.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/FcrepoSolrIndexingConfig.java
@@ -37,7 +37,7 @@ public class FcrepoSolrIndexingConfig extends BasePropsConfig {
     @Value("${solr.fcrepo.checkHasIndexingTransformation:true}")
     private boolean checkHasIndexingTransformation;
 
-    @Value("${solr.fcrepo.defaultTransform:}")
+    @Value("${solr.fcrepo.defaultTransform:org/fcrepo/camel/indexing/solr/default_transform.xsl}")
     private String defaultTransform;
 
     @Value("${solr.input.stream:broker:topic:fedora}")

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
@@ -263,8 +263,7 @@ public class RouteTest {
         final var context = camelContext.adapt(ModelCamelContext.class);
 
         AdviceWith.adviceWith(context, "FcrepoSolrUpdater", a -> {
-                a.mockEndpointsAndSkip("fcrepo*");
-                a.mockEndpointsAndSkip("http4*");
+                a.mockEndpointsAndSkip("xslt:*");
             });
 
         AdviceWith.adviceWith(context, "FcrepoSolrSend", a -> {
@@ -275,8 +274,11 @@ public class RouteTest {
         solrUpdateEndPoint.expectedMessageCount(1);
         solrUpdateEndPoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
-        template.sendBodyAndHeaders("direct:update.solr", "",
-                createEvent(baseURL + fileID, eventTypes));
+        final var headers = createEvent(baseURL + fileID, eventTypes);
+        // Need to add the header as it is set in FcrepoSolrIndexer
+        headers.put("CamelIndexingTransformation", "org/fcrepo/camel/indexing/solr/default_transform.xsl");
+
+        template.sendBodyAndHeaders( "direct:update.solr", "", headers);
 
         MockEndpoint.assertIsSatisfied(solrUpdateEndPoint);
     }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3940

# What does this Pull Request do?
Alters Thread.onSpinWait to use latch and await to avoid using CPU cycles to wait.
Also adds additional debug/trace logging to Solr route
Adds the default transform as the default on the property for Solr indexing
Adds some additional documentation on Solr indexing.

# How should this be tested?

Run the camel-toolbox before this PR and see 95-100% CPU usage by java when no messages are being processed, after this is much lower.  (Credit to @pwinckles for the work)

You can also increase the log level to trace to see additional messages. 

Lastly before this PR if you do not define the `solr.fcrepo.defaultTransform` property there is no default transform. After you will get the internal one.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
