### PR TITLE
Make containment configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ indexes objects into an external Solr server.
 | solr.filter.containers | A comma-separate list of containers that should be ignored by the indexer| http://localhost:8080/fcrepo/rest/audit |
 | solr.username |   Optional username for a Solr server protected with Basic Auth. Must be used in combination with solr.password | |
 | solr.password |   Optional password for a Solr server protected with Basic Auth. Must be used in combination with solr.username | |
-
+| solr.include.containment | When true, include containment triples in the indexing process.   | false |
 
 **Note**: You must start with the `file://` protocol when defining the path to a custom XSLT for either the `solr.fcrepo.defaultTransform` 
 or within the resource using the `http://fedora.info/definitions/v4/indexing#hasIndexingTransformation` predicate. 

--- a/fcrepo-camel-common/pom.xml
+++ b/fcrepo-camel-common/pom.xml
@@ -35,6 +35,17 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/fcrepo-camel-common/src/test/java/org/fcrepo/camel/common/TestTracer.java
+++ b/fcrepo-camel-common/src/test/java/org/fcrepo/camel/common/TestTracer.java
@@ -1,0 +1,35 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel.common;
+
+import org.apache.camel.impl.engine.DefaultTracer;
+import org.slf4j.Logger;
+
+/**
+ * A test tracer for logging camel routes under our control.
+ * @author whikloj
+ *
+ * To use, before adapting the context add camelContext.setTracer(new TestTracer(logger));
+ * i.e.
+ *  final Logger LOGGER = LoggerFactory.getLogger(FcrepoSolrIndexer.class);
+ *  camelContext.setTracer(new TestTracer(LOGGER));
+ *  final var context = camelContext.adapt(ModelCamelContext.class);
+ *  AdviceWith.adviceWith(context, "FcrepoSolrIndexer", a -%lt; {
+ */
+public class TestTracer extends DefaultTracer {
+    private final Logger LOGGER;
+
+    public TestTracer(final Logger logger) {
+        super();
+        this.LOGGER = logger;
+        this.setTracePattern("%-4.4s [%-20.20s] [%-40.40s]");
+    }
+
+    @Override
+    protected void dumpTrace(final String out) {
+        LOGGER.info(out);
+    }
+}

--- a/fcrepo-indexing-solr/pom.xml
+++ b/fcrepo-indexing-solr/pom.xml
@@ -72,6 +72,13 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>fcrepo-camel-common</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/FcrepoSolrIndexingConfig.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/FcrepoSolrIndexingConfig.java
@@ -64,6 +64,9 @@ public class FcrepoSolrIndexingConfig extends BasePropsConfig {
     @Value("${solr.password:}")
     private String solrPassword;
 
+    @Value("${solr.include.containment:false}")
+    private boolean includeContainment;
+
     public boolean isCheckHasIndexingTransformation() {
         return checkHasIndexingTransformation;
     }
@@ -102,6 +105,9 @@ public class FcrepoSolrIndexingConfig extends BasePropsConfig {
 
     public String getSolrPassword() {
         return solrPassword;
+    }
+    public boolean isIncludeContainment() {
+        return includeContainment;
     }
 
     @Bean(name = "http")

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
@@ -15,9 +15,11 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.spring.javaconfig.CamelConfiguration;
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.camel.common.TestTracer;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -39,6 +41,7 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_DATE_TIME;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_EVENT_TYPE;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_RESOURCE_TYPE;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Test the route workflow.
@@ -47,8 +50,11 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
  * @since 2015-04-10
  */
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ContextConfiguration(classes = {RouteTest.ContextConfig.class}, loader = AnnotationConfigContextLoader.class)
 public class RouteTest {
+
+    private static final Logger LOGGER = getLogger(RouteTest.class);
 
     private static final long ASSERT_PERIOD_MS = 5000;
     private final String EVENT_NS = "https://www.w3.org/ns/activitystreams#";
@@ -86,7 +92,6 @@ public class RouteTest {
 
     }
 
-    @DirtiesContext
     @Test
     public void testEventTypeRouter() throws Exception {
 
@@ -112,12 +117,10 @@ public class RouteTest {
         MockEndpoint.assertIsSatisfied(deleteEndpoint, indexEndpoint);
     }
 
-    @DirtiesContext
     @Test
     public void testFilterAuditEvents() throws Exception {
 
         final List<String> eventTypes = asList(EVENT_NS + "ResourceCreation");
-
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, "FcrepoSolrIndexer", a -> {
             a.replaceFromWith("direct:start");
@@ -141,7 +144,6 @@ public class RouteTest {
         MockEndpoint.assertIsSatisfied(deleteEndpoint, updateEndpoint);
     }
 
-    @DirtiesContext
     @Test
     public void testFilterAuditExactMatch() throws Exception {
 
@@ -169,10 +171,8 @@ public class RouteTest {
 
     }
 
-    @DirtiesContext
     @Test
     public void testFilterAuditNearMatch() throws Exception {
-
         final List<String> eventTypes = asList(EVENT_NS + "ResourceCreation");
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, "FcrepoSolrIndexer", a -> {
@@ -196,12 +196,11 @@ public class RouteTest {
 
     }
 
-    @DirtiesContext
     @Test
     public void testPrepareRouterIndexable() throws Exception {
 
         final List<String> eventTypes = asList(EVENT_NS + "ResourceCreation");
-
+        camelContext.setTracer(new TestTracer(LOGGER));
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, "FcrepoSolrIndexer", a -> {
             a.replaceFromWith("direct:start");
@@ -225,7 +224,6 @@ public class RouteTest {
         MockEndpoint.assertIsSatisfied(deleteEndpoint, updateEndpoint);
     }
 
-    @DirtiesContext
     @Test
     public void testPrepareRouterContainer() throws Exception {
 
@@ -256,7 +254,6 @@ public class RouteTest {
         MockEndpoint.assertIsSatisfied(deleteEndpoint, updateEndpoint);
     }
 
-    @DirtiesContext
     @Test
     public void testUpdateRouter() throws Exception {
 
@@ -285,7 +282,6 @@ public class RouteTest {
         MockEndpoint.assertIsSatisfied(solrUpdateEndPoint);
     }
 
-    @DirtiesContext
     @Test
     public void testDeleteRouter() throws Exception {
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <!-- jared's -->
     <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
     <!-- plugins -->
+    <jar.plugin.version>3.0.2</jar.plugin.version>
     <jetty.plugin.version>9.4.34.v20201102</jetty.plugin.version>
     <jetty.users.file>${project.build.directory}/test-classes/jetty-users.properties</jetty.users.file>
     <sonatype.host>s01.oss.sonatype.org</sonatype.host>
@@ -570,6 +571,12 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.plugin.version}</version>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
Add a tracer to see routes in tests

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3939

# What does this Pull Request do?
Adds a new configuration argument to allow users to include containment triples in the RDF pulled from Fedora for Solr indexing.

# How should this be tested?

Create a custom XSLT that includes a field for containment triples.
Before this PR you will never see any triples.
After this PR you will still never see any triples.
Add the property `solr.include.containment=true` to your properties file.
Now you will see containment triples.

Example XSLT that returns all RDF as a multi-valued field.
```xsl
<?xml version="1.0" ?>
<xsl:stylesheet version="1.0"
    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:fedora="http://fedora.info/definitions/v4/repository#"
    xmlns:ldp="http://www.w3.org/ns/ldp#"
    exclude-result-prefixes="rdf fedora ldp"
>

    <xsl:template match="/">
      <xsl:apply-templates select="rdf:RDF/rdf:Description"/>
    </xsl:template>

    <xsl:template match="rdf:Description">
    <add>
        <doc>
            <field name="id"><xsl:value-of select="@rdf:about" /></field>
            <xsl:apply-templates />
        </doc>
    </add>
    </xsl:template>


    <xsl:template match="child::*">
         <field>
           <xsl:attribute name="name"><xsl:value-of select="concat(local-name(), '_ms')"/></xsl:attribute>
           <xsl:choose>
             <xsl:when test="child::text()">
               <xsl:value-of select="child::text()"/>
             </xsl:when>
             <xsl:when test="@rdf:resource">
               <xsl:value-of select="@rdf:resource"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:comment>This is <xsl:value-of select="local-name()"/></xsl:comment>
             </xsl:otherwise>
           </xsl:choose>
         </field>
    </xsl:template>

</xsl:stylesheet>
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
