### PR TITLE
Fix docker-compose and github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,25 +13,29 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        java: [ '11' ]
+        experimental: [ false ]
+        # JDK 17  build testing. Allowed to fail as marked experimental
+        include:
+          - java: 17
+            os: ubuntu-latest
+            experimental: true
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U clean install
 
@@ -43,11 +47,12 @@ jobs:
       - name: Git support longpaths
         run: git config --global core.longpaths true
       - name: Checkout fcrepo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/docker-compose/camel-toolbox-config/configuration.properties
+++ b/docker-compose/camel-toolbox-config/configuration.properties
@@ -1,5 +1,5 @@
 fcrepo.baseUrl=http://fcrepo:8080/fcrepo/rest
-fcrepo.authHost=localhost
+fcrepo.authHost=fcrepo
 
 jms.brokerUrl=tcp://fcrepo:61616
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3956

# What does this Pull Request do?
Fixes the docker-compose Fedora configuration properties for `fcrepo.authHost` and updates the Github actions versions.

# How should this be tested?

Build will not show warnings and running a `docker-compose up -d` in the docker-compose directory should give you a fully functional setup.

# Additional Notes:

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers
