### PR TITLE
Remove obsolete note from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Additional background information is available on the Fedora Wiki on the
 * Solr
 * Fedora 6
 
-NOTE:  This is project is currently in a state of flux as we are in the process of upgrading it to support Java 11 and Camel 3.9.x
-Currently the Solr, ActiveMQ, Reindexing, and LDPath microservices are available. Triplestore indexing and Fixity are coming soon.
-
 ## Building
 
 To build these projects use this command


### PR DESCRIPTION
As discussed on the October 17 call, this note is no longer accurate.
