### PR TITLE
Use maintained Docker images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-openjdk-11-slim AS build
+FROM maven:3-eclipse-temurin-11 AS build
 
 WORKDIR /build
 
@@ -7,7 +7,7 @@ COPY . ./
 # Build with maven, if fcrepo-camel-toolbox-app-*-driver.jar does not exist:
 RUN [ -e "fcrepo-camel-toolbox-app/target/"fcrepo-camel-toolbox-app-*-driver.jar ] || mvn clean package
 
-FROM openjdk:11-jre-slim AS app
+FROM eclipse-temurin:11-jre AS app
 
 WORKDIR /usr/local/fcrepo-camel-toolbox
 


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-4014](https://fedora-repository.atlassian.net/browse/FCREPO-4014)
* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

Use maintained Docker images in Dockerfile

# What's new?

* Switch from `maven:3-openjdk-11-slim` to `maven:3-eclipse-temurin-11` for stage "build"
* Switch from `openjdk:9-jdk11-slim` to `eclipse-temurin:11-jre` for stage "app"

# How should this be tested?

* Build the Docker image locally:
```
mvn clean install
FCREPO_CAMEL_TOOLBOX_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
docker buildx build --load --tag="fcrepo/fcrepo-camel-toolbox" --tag="fcrepo/fcrepo-camel-toolbox:${FCREPO_CAMEL_TOOLBOX_VERSION}" .
```
* Then to start, the Camel Toolbox, Fedora, Fuseki, and Solr containers run
```
cd ./docker-compose
docker compose up -d
```
* Watch the Logs of Camel-Toolbox:
```
docker compose logs --follow  camel-toolbox
```
* Create some resources in Fedora 6 [](http://localhost:8080) and see how Camel-Toolbox indexes them into Solr and Fuseki

# Additional Notes:
The previously used images are no longer maintained.

The Eclipse Temurin images are based on Ubuntu LTS releases and Alpine. So this also switches the base OS used in the container from Debian 11 (Bullseye) to Ubuntu 24.04 LTS (Noble Numbat).

# Interested parties
@fcrepo/committers
