### PR TITLE
removed version and latest tag form compose setup as deprecated

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.6"
-
 services:
   fcrepo:
-    image: fcrepo/fcrepo:latest
+    image: fcrepo/fcrepo:6-tomcat9
     ports:
       - "8080:8080"
+      - "61616:61616"
+      - "61613:61613"
     environment:
       CATALINA_OPTS: "-Dfcrepo.jms.baseUrl=http://fcrepo:8080"
 
@@ -33,3 +33,15 @@ services:
     command:
       - -c
       - "/config/configuration.properties"
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     image: fcrepo/fcrepo:6-tomcat9
     ports:
       - "8080:8080"
-      - "61616:61616"
-      - "61613:61613"
     environment:
       CATALINA_OPTS: "-Dfcrepo.jms.baseUrl=http://fcrepo:8080"
 
@@ -33,15 +31,3 @@ services:
     command:
       - -c
       - "/config/configuration.properties"
-
-  prometheus:
-    image: prom/prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "3000:3000"


### PR DESCRIPTION
# What does this Pull Request do?
Removes the version which is deprecated from docker compose and targets a tagged fcrepo release as we deprescated the latest tag 

# How should this be tested?

Ensure docker compose stack still runs 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
