### PR TITLE
adding codecov to build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U clean install
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
 
   deploy:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
# What does this Pull Request do?
Adds CodeCov action to build to get code coverage reports at https://app.codecov.io/github/fcrepo-exts/fcrepo-camel-toolbox/

# How should this be tested?

A description of what steps someone could take to:
* Check build action for successful run of codecov job and look for results at https://app.codecov.io/github/fcrepo-exts/fcrepo-camel-toolbox/

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
