### PR TITLE
Correct the default admin user/pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ then the asynchonous integrations will be less prone to configuration errors.
 | Name      | Description| Default Value |
 | :---      | :---| :----   |
 | fcrepo.baseUrl | The base url endpoint for your Fedora installation.  | http://localhost:8080/fcrepo/rest |
-| fcrepo.authUsername | A valid username      | fcrepoAdmin |
-| fcrepo.authPassword | A valid password      | fcrepoAdmin |
+| fcrepo.authUsername | A valid username      | fedoraAdmin |
+| fcrepo.authPassword | A valid password      | fedoraAdmin |
 | fcrepo.authHost | The hostname of the Fedora installation which the fcrepo.authUsername and fcrepo.authPassword should be applied to      | localhost |
 | error.maxRedeliveries | The maximum number of redelivery attempts before failing.      | 10 |
 


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: (link)

N/A

# What does this Pull Request do?

`fcrepoAdmin` does not seem to be the default username password, rather `fedoraAdmin` is documented in other places such as these [workshop slides](https://docs.google.com/presentation/d/1-KiXRxX-EOlMZ97Ec1Y2-3uq5lprGyAZffzfsfg0if4/edit?slide=id.g37aee279416_0_55#slide=id.g37aee279416_0_55) (and possibly in code, but I am not sure if I am reading it correctly: https://github.com/fcrepo/fcrepo/blob/0696b1830118b6f41091e65553b5589bb252daf4/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java#L37) 

# What's new?

Changes the README.md to match other docs. 

# How should this be tested?

Confirm the assumptions against fcrepo code.
Confirm the login works with default docker compose settings.

# Additional Notes:

Depending on if fcrepo is meant to be correct, then the fix might be elsewhere.

# Interested parties

@fcrepo/committers
